### PR TITLE
Add support for jumphosts via ProxyCommand

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,10 @@ Connect to an instance by DNS name as user "my-user" and run the command "ls"
 
     $ mssh my-user@ec2-[ec2 IP].us-east-1.compute.amazonaws.com -t [instance id] ls
 
+Connect to an instance via jump host
+
+    $ mssh -J my-user@[jump host id] user@[instance id]
+
 Run sftp against instance using the AWS CLI profile "otherprofile" and transferring my-file
 
     $ msftp -pr otherprofile [instance id]:my-file

--- a/doc/source/README.rst
+++ b/doc/source/README.rst
@@ -58,6 +58,10 @@ Connect to an instance by DNS name as user "my-user" and run the command "ls"
 
     $ mssh my-user@ec2-[ec2 IP].us-east-1.compute.amazonaws.com -t [instance id] ls
 
+Connect to an instance via jump host
+
+    $ mssh -J my-user@[jump host id] user@[instance id]
+
 Run sftp against instance using the AWS CLI profile "beta" and transferring my-file
 
     $ msftp -pr beta [instance id]:my-file

--- a/ec2instanceconnectcli/EC2InstanceConnectCommand.py
+++ b/ec2instanceconnectcli/EC2InstanceConnectCommand.py
@@ -56,7 +56,9 @@ class EC2InstanceConnectCommand(object):
         if len(self.program_command) > 0:
             command = "{0} {1}".format(command, self.program_command)
 
-        if len(self.instance_bundles) > 1:
+        if len(self.instance_bundles) > 1 and self.program == 'ssh':
+            command = "{0} -o \"ProxyCommand=ssh -i {1} -W '[%h]:%p' {2}\"".format(command, self.key_file, self._get_target(self.instance_bundles[1]))
+        elif len(self.instance_bundles) > 1:
             command = "{0} {1}".format(command, self._get_target(self.instance_bundles[1]))
 
         self.logger.debug('Generated command: {0}'.format(command))

--- a/ec2instanceconnectcli/input_parser.py
+++ b/ec2instanceconnectcli/input_parser.py
@@ -68,6 +68,16 @@ def parseargs(args, mode='ssh'):
     ]
     # We do this as an array to support future commands that may need multiple instances (eg, scp)
 
+    if args[0].jumphost:
+        instance_bundles.append(
+            {
+                'profile': args[0].profile,
+                'region': args[0].region,
+                'zone': args[0].zone,
+                'target': args[0].jumphost
+            }
+        )
+
     # Process out the command flags & target data
     flags, command, instance_bundles = _parse_command_flags(args[1], instance_bundles, is_ssh=(mode=='ssh'))
 

--- a/ec2instanceconnectcli/mops.py
+++ b/ec2instanceconnectcli/mops.py
@@ -54,6 +54,7 @@ def main(program, mode):
     parser.add_argument('-z', '--zone', action='store', help='Availability zone', type=str, metavar='')
     parser.add_argument('-u', '--profile', action='store', help='AWS Config Profile', type=str, default=DEFAULT_PROFILE, metavar='')
     parser.add_argument('-t', '--instance_id', action='store', help='EC2 Instance ID. Required if target is hostname', type=str, default=DEFAULT_INSTANCE, metavar='')
+    parser.add_argument('-J', '--jumphost', action='store', help='EC2 Jump host Instance ID.', type=str, default=DEFAULT_INSTANCE, metavar='')
     parser.add_argument('-d', '--debug', action="store_true", help='Turn on debug logging')
 
     args = parser.parse_known_args()

--- a/tests/test_input_parser.py
+++ b/tests/test_input_parser.py
@@ -22,6 +22,7 @@ class TestInputParser(TestBase):
     parser = argparse.ArgumentParser(description='alternate usage: mssh [user]@[instance-id]:[port]')
     parser.add_argument('-u', '--profile', help='AWS Config Profile', type=str, default='default')
     parser.add_argument('-t', '--instance_id', help='EC2 Instance ID', type=str, default='')
+    parser.add_argument('-J', '--jumphost', action='store', help='EC2 Jump host Instance ID.', type=str, default='')
     parser.add_argument('-r', '--region', action='store', help='AWS region', type=str)
     parser.add_argument('-z', '--zone', action='store', help='Availability zone', type=str)
     parser.add_argument('-U', '--dest_profile', action='store',
@@ -132,3 +133,14 @@ class TestInputParser(TestBase):
                                              '-z', 'bad zone', self.dns_name])
 
         self.assertRaises(AssertionError, input_parser.parseargs, args)
+
+    def test_jumphost(self):
+        args = self.parser.parse_known_args(['-J', 'user2@i-ascacacsacacaascas', "user1@{0}".format('i-afafafafafafafafaf')])
+        bundles, flags, command = input_parser.parseargs(args, 'ssh')
+        print(bundles)
+        self.assertEqual(bundles, [
+            {'username': 'user1', 'instance_id': 'i-afafafafafafafafaf',
+            'target': None, 'zone': None, 'region': None, 'profile': 'default'},
+            {'username': 'user2', 'instance_id': 'i-ascacacsacacaascas',
+            'target': None, 'zone': None, 'region': None, 'profile': 'default'}
+        ])


### PR DESCRIPTION
*Issue #2*

*Description of changes:*
Add `-J` flag to mssh to support bastion/jumphosts via ProxyCommand.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
