### PR TITLE
Fix msftp command in windows

### DIFF
--- a/bin/msftp.cmd
+++ b/bin/msftp.cmd
@@ -36,7 +36,7 @@ from ec2instanceconnectcli import mops
 import sys
 
 def main():
-    return msftp.main("sftp", "sftp")
+    return mops.main("sftp", "sftp")
 
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
Wrong import module name

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
