### PR TITLE
Wrap command in shlex.quote()

### DIFF
--- a/ec2instanceconnectcli/EC2InstanceConnectCommand.py
+++ b/ec2instanceconnectcli/EC2InstanceConnectCommand.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import shlex
 
 class EC2InstanceConnectCommand(object):
     """
@@ -54,7 +55,7 @@ class EC2InstanceConnectCommand(object):
 
         #program specific command
         if len(self.program_command) > 0:
-            command = "{0} {1}".format(command, self.program_command)
+            command = "{0} {1}".format(command, shlex.quote(self.program_command))
 
         if len(self.instance_bundles) > 1:
             command = "{0} {1}".format(command, self._get_target(self.instance_bundles[1]))

--- a/tests/test_EC2ConnectCLI.py
+++ b/tests/test_EC2ConnectCLI.py
@@ -45,7 +45,7 @@ class TestEC2InstanceConnectCLI(TestBase):
         cli = EC2InstanceConnectCLI(instance_bundles, "", cli_command, logger.get_logger())
         cli.invoke_command()
         
-        expected_command = 'ssh -o "IdentitiesOnly=yes" -i {0} {1} {2}@{3} {4}'.format(mock_file, flag, self.default_user,
+        expected_command = 'ssh -o "IdentitiesOnly=yes" -i {0} {1} {2}@{3} \'{4}\''.format(mock_file, flag, self.default_user,
                                                                self.public_ip, command)
 
         # Check that we successfully get to the run
@@ -76,7 +76,7 @@ class TestEC2InstanceConnectCLI(TestBase):
         cli = EC2InstanceConnectCLI(instance_bundles, "", cli_command, logger.get_logger())
         cli.invoke_command()
 
-        expected_command = 'ssh -o "IdentitiesOnly=yes" -i {0} {1} {2}@{3} {4}'.format(mock_file, flag, self.default_user,
+        expected_command = 'ssh -o "IdentitiesOnly=yes" -i {0} {1} {2}@{3} \'{4}\''.format(mock_file, flag, self.default_user,
                                                                self.private_ip, command)
 
         # Check that we successfully get to the run
@@ -107,7 +107,7 @@ class TestEC2InstanceConnectCLI(TestBase):
         cli = EC2InstanceConnectCLI(instance_bundles, "", cli_command, logger.get_logger())
         cli.invoke_command()
 
-        expected_command = 'ssh -o "IdentitiesOnly=yes" -i {0} {1} {2}@{3} {4}'.format(mock_file, flag, self.default_user,
+        expected_command = 'ssh -o "IdentitiesOnly=yes" -i {0} {1} {2}@{3} \'{4}\''.format(mock_file, flag, self.default_user,
                                                                host, command)
         # Check that we successfully get to the run
         # Since both target and availability_zone are provided, mock_instance_data should not be called
@@ -133,7 +133,7 @@ class TestEC2InstanceConnectCLI(TestBase):
         mock_instance_data.return_value = self.instance_info
         mock_push_key.return_value = None
 
-        expected_command = 'sftp -o "IdentitiesOnly=yes" -i {0} {1} {2}@{3}:{4} {5}'.format(mock_file, flag, self.default_user,
+        expected_command = 'sftp -o "IdentitiesOnly=yes" -i {0} {1} {2}@{3}:{4} \'{5}\''.format(mock_file, flag, self.default_user,
                                                                self.public_ip, 'file1', command)
 
         cli_command = EC2InstanceConnectCommand("sftp", instance_bundles, mock_file, flag, command, logger.get_logger())
@@ -166,7 +166,7 @@ class TestEC2InstanceConnectCLI(TestBase):
         mock_instance_data.return_value = self.instance_info
         mock_push_key.return_value = None
 
-        expected_command = 'scp -o "IdentitiesOnly=yes" -i {0} {1} {2}@{3}:{4} {5} {6}@{7}:{8}'.format(mock_file, flag, self.default_user,
+        expected_command = 'scp -o "IdentitiesOnly=yes" -i {0} {1} {2}@{3}:{4} \'{5}\' {6}@{7}:{8}'.format(mock_file, flag, self.default_user,
                                                                                 self.public_ip, 'file1', command,
                                                                                 self.default_user,
                                                                                 self.public_ip, 'file4')


### PR DESCRIPTION
*Issue #, if available:* #24

*Description of changes:*

This updates `get_command()` by wrapping the command in [shlex.quote()](https://docs.python.org/3/library/shlex.html#shlex.quote).

> Return a shell-escaped version of the string s. The returned value is a string that can safely be used as one token in a shell command line, for cases where you cannot use a list.

As seen in the linked issue (#24) the mssh command has trouble executing commands that contain escaped quotes `'` such as those generated automatically by Ansible. These quotes can be meaningful and may cause errors if omitted. Wrapping the whole command in shlex.quote preserves the original quotes and solves the issues.

I updated the test cases to expect the quotes in the command. As far as I can tell, this shouldn't _break_ anything but I'm open to thoughts or concerns. It may also be slightly more secure that before, not that you should be running un-trusted commands through ssh anyways

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
