### PR TITLE
Adding argument to allow forcing use of EC2 private IP

### DIFF
--- a/ec2instanceconnectcli/EC2InstanceConnectCLI.py
+++ b/ec2instanceconnectcli/EC2InstanceConnectCLI.py
@@ -66,7 +66,11 @@ class EC2InstanceConnectCLI(object):
             bundle['zone'] = instance_info.availability_zone
             #If host_info is not available, fallback to using public ipaddress and then private ipaddress.
             if not bundle['host_info']:
-                bundle['host_info'] = instance_info.public_ip if instance_info.public_ip else instance_info.private_ip
+                if bundle['private']:
+                    bundle['host_info'] = instance_info.private_ip    
+                else:
+                    bundle['host_info'] = instance_info.public_ip if instance_info.public_ip else instance_info.private_ip
+                    
             self.logger.debug('Successfully got instance information from EC2 API for {0}'.format(bundle['instance_id']))
 
     def handle_keys(self):

--- a/ec2instanceconnectcli/input_parser.py
+++ b/ec2instanceconnectcli/input_parser.py
@@ -64,7 +64,8 @@ def parseargs(args, mode='ssh'):
             'profile': args[0].profile,
             'instance_id': args[0].instance_id,
             'region': args[0].region,
-            'zone': args[0].zone
+            'zone': args[0].zone,
+            'private': args[0].private
         }
     ]
     # We do this as an array to support future commands that may need multiple instances (eg, scp)

--- a/ec2instanceconnectcli/mops.py
+++ b/ec2instanceconnectcli/mops.py
@@ -57,6 +57,7 @@ def main(program, mode):
     parser.add_argument('-u', '--profile', action='store', help='AWS Config Profile', type=str, default=DEFAULT_PROFILE, metavar='')
     parser.add_argument('-t', '--instance_id', action='store', help='EC2 Instance ID. Required if target is hostname', type=str, default=DEFAULT_INSTANCE, metavar='')
     parser.add_argument('-d', '--debug', action="store_true", help='Turn on debug logging')
+    parser.add_argument('-p', '--private', action="store_true", help='Force usage of private IP')
 
     args = parser.parse_known_args()
 


### PR DESCRIPTION
Fixes #16 
*Issue 16: Support using private ip of an instance without passing the private ip as an argument*

*Description of changes:*
Added optional argument of `-p` or `--private` that will force the use of private IP when instance ID is specified as host.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
